### PR TITLE
Add get and set email forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This project is a work-in-progress, see the following table for supported featur
 ||Create|POST|✔️|
 ||Update|PATCH|✔️|
 ||Delete|DELETE|✔️|
+|Email|Retrieve|GET|✔️|
+||Set|POST|✔️|
 |PURL|List|GET|✔️|
 ||Retrieve|GET|✔️|
 ||Create|POST|✔️|

--- a/omglol/common_test.go
+++ b/omglol/common_test.go
@@ -86,3 +86,23 @@ func randStringBytes(n int) string {
     }
     return string(b)
 }
+
+func listsHaveSameElements(t *testing.T, list1 []string, list2 []string) bool {
+    if len(list1) == 0 && len(list2) == 0 {
+		t.Log("Both lists are length 0")
+        return true
+    }
+    
+    map2 := make(map[string]bool)
+    for _, str := range list2 {
+        map2[str] = true
+    }
+
+    for _, str := range list1 { 
+        if _, ok := map2[str]; !ok {
+            return false
+        }
+    }
+    
+    return true
+}

--- a/omglol/email.go
+++ b/omglol/email.go
@@ -1,0 +1,52 @@
+package omglol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Get email forwarding address(es) for a domain. See https://api.omg.lol/#token-get-email-retrieve-forwarding-addresses
+func (c *Client) GetEmail(domain string) ([]string, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/address/%s/email", c.HostURL, domain), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var r emailResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return nil, err
+	}
+
+	return r.Response.DestinationArray, nil
+}
+
+// Set email forwarding address(es) for a domain. See https://api.omg.lol/#token-post-email-set-forwarding-addresses
+func (c *Client) SetEmail(domain string, destination []string) error {
+	jsonData := fmt.Sprintf(`{"destination": "%s"}`, strings.Join(destination, ", "))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/address/%s/email", c.HostURL, domain), bytes.NewBuffer([]byte(jsonData)))
+	if err != nil {
+		return err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("sent: %s, error: %w", jsonData, err)
+	}
+
+	var r emailResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return err
+	}
+
+	return nil
+}

--- a/omglol/email.go
+++ b/omglol/email.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Get email forwarding address(es) for a domain. See https://api.omg.lol/#token-get-email-retrieve-forwarding-addresses
-func (c *Client) GetEmail(domain string) ([]string, error) {
+func (c *Client) GetEmails(domain string) ([]string, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/address/%s/email", c.HostURL, domain), nil)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func (c *Client) GetEmail(domain string) ([]string, error) {
 }
 
 // Set email forwarding address(es) for a domain. See https://api.omg.lol/#token-post-email-set-forwarding-addresses
-func (c *Client) SetEmail(domain string, destination []string) error {
+func (c *Client) SetEmails(domain string, destination []string) error {
 	jsonData := fmt.Sprintf(`{"destination": "%s"}`, strings.Join(destination, ", "))
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/address/%s/email", c.HostURL, domain), bytes.NewBuffer([]byte(jsonData)))
 	if err != nil {

--- a/omglol/email_test.go
+++ b/omglol/email_test.go
@@ -1,0 +1,74 @@
+package omglol
+
+import (
+	"testing"
+)
+
+func TestSetAndGetEmail(t *testing.T) {
+	sleep()
+	c, err := NewClient(testEmail, testKey, testHostURL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	destinations := []string{testEmail}
+	if err := c.SetEmail(testOwnedDomain, destinations); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	sleep()
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	destination, err := c.GetEmail(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if destination != nil {
+		t.Logf("%+v\n", destination)
+
+		expected := []string{testEmail}
+		if destination[0] != testEmail {
+			t.Errorf("Expected %s, got %s", expected, destination)
+		}
+	} else {
+		t.Error("Account destination returned 'nil'.")
+	}
+}
+
+func TestClearAndGetEmail(t *testing.T) {
+	sleep()
+	c, err := NewClient(testEmail, testKey, testHostURL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	destinations := []string{}
+	if err := c.SetEmail(testOwnedDomain, destinations); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	sleep()
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	destination, err := c.GetEmail(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if destination != nil {
+		t.Logf("%+v\n", destination)
+
+		if len(destination) != 0 {
+			t.Errorf("Expected %d, got %d", 0, len(destination))
+		}
+	} else {
+		t.Error("Account destination returned 'nil'.")
+	}
+}

--- a/omglol/email_test.go
+++ b/omglol/email_test.go
@@ -4,50 +4,29 @@ import (
 	"testing"
 )
 
-func TestSetAndGetEmail(t *testing.T) {
+func TestGetClearAndSetEmails(t *testing.T) {
 	sleep()
 	c, err := NewClient(testEmail, testKey, testHostURL)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	destinations := []string{testEmail}
-	if err := c.SetEmail(testOwnedDomain, destinations); err != nil {
-		t.Errorf(err.Error())
-	}
-
-	sleep()
-
+	originalDestinations, err := c.GetEmails(testOwnedDomain)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	destination, err := c.GetEmail(testOwnedDomain)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
+	if originalDestinations != nil {
+		t.Logf("Original Destinations: %+v\n", originalDestinations)
 
-	if destination != nil {
-		t.Logf("%+v\n", destination)
-
-		expected := []string{testEmail}
-		if destination[0] != testEmail {
-			t.Errorf("Expected %s, got %s", expected, destination)
-		}
 	} else {
 		t.Error("Account destination returned 'nil'.")
 	}
-}
 
-func TestClearAndGetEmail(t *testing.T) {
 	sleep()
-	c, err := NewClient(testEmail, testKey, testHostURL)
-	if err != nil {
-		t.Errorf(err.Error())
-	}
 
-	destinations := []string{}
-	if err := c.SetEmail(testOwnedDomain, destinations); err != nil {
+	clear := []string{}
+	if err := c.SetEmails(testOwnedDomain, clear); err != nil {
 		t.Errorf(err.Error())
 	}
 
@@ -57,18 +36,38 @@ func TestClearAndGetEmail(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	destination, err := c.GetEmail(testOwnedDomain)
+	destination, err := c.GetEmails(testOwnedDomain)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
 	if destination != nil {
-		t.Logf("%+v\n", destination)
+		t.Logf("Destinations once cleared: %+v\n", destination)
 
 		if len(destination) != 0 {
 			t.Errorf("Expected %d, got %d", 0, len(destination))
 		}
 	} else {
 		t.Error("Account destination returned 'nil'.")
+	}
+
+	if err := c.SetEmails(testOwnedDomain, originalDestinations); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	finalDestinations, err := c.GetEmails(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if finalDestinations != nil {
+		t.Logf("Final Destinations: %+v\n", finalDestinations)
+
+	} else {
+		t.Error("Account destination returned 'nil'.")
+	}
+
+	if !listsHaveSameElements(t, originalDestinations, finalDestinations) {
+		t.Errorf("Original: %s does not match final: %s.", originalDestinations, finalDestinations)
 	}
 }

--- a/omglol/models.go
+++ b/omglol/models.go
@@ -145,6 +145,17 @@ type dnsChangeResponse struct {
 	} `json:"response"`
 }
 
+type emailResponse struct {
+	Request  request `json:"request"`
+	Response struct {
+		Message           string   `json:"message"`
+		DestinationString string   `json:"destination_string"`
+		DestinationArray  []string `json:"destination_array"`
+		Address           string   `json:"address"`
+		EmailAddress      string   `json:"email_address"`
+	} `json:"response"`
+}
+
 type Paste struct {
 	Title      string `json:"title"`
 	Content    string `json:"content"`


### PR DESCRIPTION
Just two commands this time. A few questions:

- GET /address/%s/email returns the forwarding address(es) in both array and string forms (the string being the array joined with commas.) POST /address/%s/email expects the forwarding address(es) in the string form only. To me, it makes the most sense to deal with these as an array in all cases, and disregard the string output from GET/convert to string output for POST. What do you think?

- It's unclear to me where you want things to be passed/returned as pointers vs. not. In this PR, nothing is passed or returned as a pointer. What's your thinking on when a pointer is appropriate and when not?
- 