### PR TITLE
get/set web

### DIFF
--- a/omglol/models.go
+++ b/omglol/models.go
@@ -169,3 +169,18 @@ type PersistentURL struct {
 	Counter *int64 `json:"counter"`
 	Listed  bool   `json:"listed"`
 }
+
+type Web struct {
+	Message      string `json:"message"`
+	Content      string `json:"content"`
+	ContentBytes []byte `json:"omitempty"`
+	Type         string `json:"type"`
+	Theme        string `json:"theme"`
+	CSS          string `json:"css"`
+	Head         string `json:"head"`
+	Verified     bool   `json:"verified"`
+	PFP          string `json:"pfp"`
+	Metadata     string `json:"metadata"`
+	Branding     string `json:"branding"`
+	Modified     string `json:"modified"`
+}

--- a/omglol/web.go
+++ b/omglol/web.go
@@ -1,0 +1,81 @@
+package omglol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Get webpage content for a domain. See https://api.omg.lol/#token-get-web-retrieve-web-page-content
+func (c *Client) GetWeb(domain string) (*Web, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/address/%s/web", c.HostURL, domain), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	type webResponse struct {
+		Request  request `json:"request"`
+		Response Web     `json:"response"`
+	}
+
+	var w webResponse
+	if err = json.Unmarshal(body, &w); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return nil, err
+	}
+	w.Response.ContentBytes = []byte(w.Response.Content)
+	return &w.Response, nil
+}
+
+// Update webpage content for a domain. See https://api.omg.lol/#token-post-web-update-web-page-content-and-publish
+func (c *Client) SetWeb(domain string, content []byte, publish bool) (bool, error) {
+	type setWebInput struct {
+		Content string `json:"content"`
+		Publish bool   `json:"publish,omitempty"`
+	}
+
+	input := setWebInput{string(content), publish}
+	jsonData, err := json.Marshal(input)
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/address/%s/web", c.HostURL, domain), bytes.NewBuffer([]byte(jsonData)))
+	if err != nil {
+		return false, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return false, fmt.Errorf("sent: %s, error: %w", jsonData, err)
+	}
+
+	var r apiResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return false, err
+	}
+
+	type decodedResponse struct {
+		Message string `json:"message"`
+	}
+	var m decodedResponse
+	if err := json.Unmarshal(r.Response, &m); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return false, err
+	}
+
+	if m.Message == "Your web content has been saved and published." {
+		return true, nil
+	} else if m.Message == "Your web content has been saved." {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("unexpected response: %s", m.Message)
+	}
+}

--- a/omglol/web_test.go
+++ b/omglol/web_test.go
@@ -1,0 +1,51 @@
+package omglol
+
+import (
+	"testing"
+)
+
+func TestGetSetRestoreWeb(t *testing.T) {
+	sleep()
+	c, err := NewClient(testEmail, testKey, testHostURL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	w, err := c.GetWeb(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	previousContent := w.Content
+	newContent := "this is the new content\n\nit has newlines\n"
+
+	sleep()
+	published, err := c.SetWeb(testOwnedDomain, []byte(newContent), false)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if published {
+		t.Errorf("Expected published to be false, got true")
+	}
+
+	sleep()
+	w, err = c.GetWeb(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if w.Content != newContent {
+		t.Errorf("Expected content '%s', got '%s'", newContent, w.Content)
+	}
+	if string(w.ContentBytes) != newContent {
+		t.Errorf("Expected ContentBytes '%s', got '%s'", newContent, string(w.Content))
+	}
+
+	sleep()
+	published, err = c.SetWeb(testOwnedDomain, []byte(previousContent), true)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if !published {
+		t.Errorf("Expected published to be true, got false")
+	}
+}

--- a/omglol/web_test.go
+++ b/omglol/web_test.go
@@ -16,6 +16,12 @@ func TestGetSetRestoreWeb(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
+	if w != nil {
+		t.Logf("Previous content: %s", w.Content)
+	} else {
+		t.Logf("Previous content was empty.")
+	}
+
 	previousContent := w.Content
 	newContent := "this is the new content\n\nit has newlines\n"
 
@@ -33,12 +39,18 @@ func TestGetSetRestoreWeb(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	if w.Content != newContent {
-		t.Errorf("Expected content '%s', got '%s'", newContent, w.Content)
-	}
-	if string(w.ContentBytes) != newContent {
-		t.Errorf("Expected ContentBytes '%s', got '%s'", newContent, string(w.Content))
-	}
+
+	if w != nil {
+		t.Logf("New content: %s", w.Content)
+		if w.Content != newContent {
+			t.Errorf("Expected content '%s', got '%s'", newContent, w.Content)
+		}
+		if string(w.ContentBytes) != newContent {
+			t.Errorf("Expected ContentBytes '%s', got '%s'", newContent, string(w.Content))
+		}
+	} else {
+		t.Errorf("GetWeb returned 'nil'.")
+	}	
 
 	sleep()
 	published, err = c.SetWeb(testOwnedDomain, []byte(previousContent), true)


### PR DESCRIPTION
@ejstreet this is not quite ready, but I'm pushing it up to get some feedback on a few things:

- The two calls here aren't symmetric in the API. `GetWeb` returns the webpage content and a bunch of other information. `SetWeb` just allows updating the content (and setting a bool to indicate whether you want it to be published or not.) I figured it made sense to return all the extra stuff you get from `GetWeb`, even if you can't take that output and feed it right back into `SetWeb`.
- The content of the web page is returned as a `string` from `GetWeb` and sent as a `string` by `SetWeb`, but I'm thinking this might make sense to be `[]byte` instead. That way, you could do things like pass in the output of `os.ReadFile("new_web_content.md")` or even `io.ReadAll(stdin)` to `GetWeb`.

Thoughts?
