### PR TITLE
Now page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ This project is a work-in-progress, see the following table for supported featur
 ||Delete|DELETE|✔️|
 |Email|Retrieve|GET|✔️|
 ||Set|POST|✔️|
+|Now|Retrieve|GET|✔️|
+||Garden|GET|✔️|
+||Update|POST|✔️|
 |PURL|List|GET|✔️|
 ||Retrieve|GET|✔️|
 ||Create|POST|✔️|

--- a/README.md
+++ b/README.md
@@ -63,5 +63,7 @@ This project is a work-in-progress, see the following table for supported featur
 ||Retrieve|GET|✔️|
 ||Create|POST|✔️|
 ||Delete|DELETE|✔️|
+|Web|Retrieve|GET|✔️|
+||Update|POST|✔️|
 
 >**Note** Features marked with a * are additional to what the API provides

--- a/omglol/models.go
+++ b/omglol/models.go
@@ -156,6 +156,24 @@ type emailResponse struct {
 	} `json:"response"`
 }
 
+type Now struct {
+	Content      string `json:"content"`
+	ContentBytes []byte `json:"omitempty"`
+	Updated      int64  `json:"updated"`
+	Listed       int    `json:"listed"`
+}
+
+type NowGardenEntry struct {
+	Address string `json:"address"`
+	URL     string `json:"url"`
+	Updated struct {
+		UnixEpochTime int64  `json:"unix_epoch_time"`
+		Iso8601Time   string `json:"iso_8601_time"`
+		Rfc2822Time   string `json:"rfc_2822_time"`
+		RelativeTime  string `json:"relative_time"`
+	} `json:"updated"`
+}
+
 type Paste struct {
 	Title      string `json:"title"`
 	Content    string `json:"content"`

--- a/omglol/now.go
+++ b/omglol/now.go
@@ -1,0 +1,104 @@
+package omglol
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Get Now page content for a domain. See https://api.omg.lol/#noauth-get-now-page-retrieve-/now-page
+func (c *Client) GetNow(domain string) (*Now, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/address/%s/now", c.HostURL, domain), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	type nowResponse struct {
+		Request  request `json:"request"`
+		Response struct {
+			Message string `json:"message"`
+			Now     Now    `json:"now"`
+		}
+	}
+
+	var r nowResponse
+	if err = json.Unmarshal(body, &r); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return nil, err
+	}
+	r.Response.Now.ContentBytes = []byte(r.Response.Now.Content)
+	return &r.Response.Now, nil
+}
+
+// Update Now page content for a domain. See https://api.omg.lol/#token-post-now-page-update-/now-page
+func (c *Client) SetNow(domain string, content []byte, listed bool) error {
+	type setNowInput struct {
+		Content string `json:"content"`
+		Listed  int    `json:"listed"`
+	}
+
+	var listedInt int
+	if listed {
+		listedInt = 1
+	} else {
+		listedInt = 0
+	}
+	input := setNowInput{string(content), listedInt}
+	jsonData, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/address/%s/now", c.HostURL, domain), bytes.NewBuffer([]byte(jsonData)))
+	if err != nil {
+		return err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return fmt.Errorf("sent: %s, error: %w", jsonData, err)
+	}
+
+	var r apiResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+// Retrieve the Now garden. See https://api.omg.lol/#noauth-get-now-page-retrieve-the-now.garden-listing
+func (c *Client) GetNowGarden() (*[]NowGardenEntry, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/now/garden", c.HostURL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	type gardenResponse struct {
+		Request  request `json:"request"`
+		Response struct {
+			Message string           `json:"message"`
+			Garden  []NowGardenEntry `json:"garden"`
+		} `json:"response"`
+	}
+
+	var g gardenResponse
+	if err := json.Unmarshal(body, &g); err != nil {
+		fmt.Printf("error unmarshalling response: %v\n", err)
+		return nil, err
+	}
+
+	return &g.Response.Garden, nil
+}

--- a/omglol/now_test.go
+++ b/omglol/now_test.go
@@ -1,0 +1,79 @@
+package omglol
+
+import (
+	"testing"
+)
+
+func TestGetSetRestoreNow(t *testing.T) {
+	sleep()
+	c, err := NewClient(testEmail, testKey, testHostURL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	w, err := c.GetNow(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if w != nil {
+		t.Logf("Previous content: %s", w.Content)
+	} else {
+		t.Logf("Previous content was empty.")
+	}
+
+	previousContent := w.Content
+	newContent := "this is a now page\n\nright now I am running tests\n"
+
+	sleep()
+	err = c.SetNow(testOwnedDomain, []byte(newContent), false)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	sleep()
+	w, err = c.GetNow(testOwnedDomain)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if w != nil {
+		t.Logf("New content: %s", w.Content)
+		if w.Content != newContent {
+			t.Errorf("Expected content '%s', got '%s'", newContent, w.Content)
+		}
+		if string(w.ContentBytes) != newContent {
+			t.Errorf("Expected ContentBytes '%s', got '%s'", newContent, string(w.Content))
+		}
+	} else {
+		t.Errorf("GetNow returned 'nil'.")
+	}
+
+	sleep()
+	err = c.SetNow(testOwnedDomain, []byte(previousContent), true)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+func TestGetNowGarden(t *testing.T) {
+	sleep()
+	c, err := NewClient(testEmail, testKey, testHostURL)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	g, err := c.GetNowGarden()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if g != nil {
+		t.Logf("Now Garden: %+v\n", *g)
+		if len(*g) <= 0 {
+			t.Error("Garden returned empty.")
+		}
+	} else {
+		t.Error("Now garden returned 'nil'.")
+	}
+}


### PR DESCRIPTION
Very similar to the Web feature, with an added "Now garden" directory
listing.

Also adds Web to supported features in README.md, which I forgot to do
in the last PR.
